### PR TITLE
ledger expects auth in bytes not hex

### DIFF
--- a/hwilib/devices/specter.py
+++ b/hwilib/devices/specter.py
@@ -90,10 +90,7 @@ class SpecterClient(HardwareWalletClient):
         if len(auth) == 0:
             signed_tx = self.query("sign %s" % tx.serialize())
         else:
-            try:
-                auth = auth.hex()
-            except:
-                pass
+            auth = auth.hex()
             signed_tx = self.query("signauth %s %s" % (tx.serialize(), auth))
         return {'psbt': signed_tx}
 


### PR DESCRIPTION
ledger expects auth in bytes not hex
please see also corresponding pull request for the checksig-hwigui repo.