### PR TITLE
formatted according to best standards

### DIFF
--- a/hwilib/devices/specter.py
+++ b/hwilib/devices/specter.py
@@ -1,17 +1,22 @@
 # Specter interaction script
-from typing import Dict, Optional, Union
-from ..serializations import PSBT
-
-from ..hwwclient import HardwareWalletClient
-from ..errors import (ActionCanceledError, BadArgumentError, 
-                           DeviceBusyError, DeviceFailureError, 
-                           UnavailableActionError)
-from ..base58 import xpub_main_2_test
-from .. import base58
+import socket
+import time
+from typing import Dict, Optional
 
 import serial
 import serial.tools.list_ports
-import socket, time
+
+from .. import base58
+from ..base58 import xpub_main_2_test
+from ..errors import (
+    ActionCanceledError,
+    BadArgumentError,
+    DeviceBusyError,
+    UnavailableActionError,
+)
+from ..hwwclient import HardwareWalletClient
+from ..serializations import PSBT
+
 
 class SpecterClient(HardwareWalletClient):
     """Create a client for a HID device that has already been opened.
@@ -19,17 +24,19 @@ class SpecterClient(HardwareWalletClient):
     This abstract class defines the methods
     that hardware wallet subclasses should implement.
     """
+
     # timeout large enough to handle xpub derivations
     TIMEOUT = 3
-    def __init__(self, path: str, password:str="", expert:bool=False) -> None:
+
+    def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
         super().__init__(path, password, expert)
-        self.simulator = (":" in path)
+        self.simulator = ":" in path
         if self.simulator:
             self.dev = SpecterSimulator(path)
         else:
             self.dev = SpecterUSBDevice(path)
 
-    def query(self, data: str, timeout:Optional[float] = None) -> str:
+    def query(self, data: str, timeout: Optional[float] = None) -> str:
         """Send a text-based query to the device and get back the response"""
         res = self.dev.query(data, timeout)
         if res == "error: User cancelled":
@@ -51,12 +58,12 @@ class SpecterClient(HardwareWalletClient):
         """
         # this should be fast
         xpub = self.query("xpub %s" % bip32_path, timeout=self.TIMEOUT)
-        # Specter returns xpub with a prefix 
+        # Specter returns xpub with a prefix
         # for a network currently selected on the device
         if self.is_testnet:
-            return {'xpub': xpub_main_2_test(xpub)}
+            return {"xpub": xpub_main_2_test(xpub)}
         else:
-            return {'xpub': xpub_test_2_main(xpub)}
+            return {"xpub": xpub_test_2_main(xpub)}
 
     def sign_tx(self, psbt: PSBT) -> Dict[str, str]:
         """Sign a partially signed bitcoin transaction (PSBT).
@@ -71,7 +78,7 @@ class SpecterClient(HardwareWalletClient):
         for i in range(len(psbt.inputs)):
             for k in signed_psbt.inputs[i].partial_sigs:
                 psbt.inputs[i].partial_sigs[k] = signed_psbt.inputs[i].partial_sigs[k]
-        return {'psbt': psbt.serialize()}
+        return {"psbt": psbt.serialize()}
 
     def sign_message(self, message: str, bip32_path: str) -> Dict[str, str]:
         """Sign a message (bitcoin message signing).
@@ -82,7 +89,7 @@ class SpecterClient(HardwareWalletClient):
 
         Return {"signature": <base64 signature string>}.
         """
-        sig = self.query('signmessage %s %s' % (bip32_path, message))
+        sig = self.query("signmessage %s %s" % (bip32_path, message))
         return {"signature": sig}
 
     def display_address(
@@ -111,34 +118,36 @@ class SpecterClient(HardwareWalletClient):
         if redeem_script is not None:
             request += f" {redeem_script}"
         address = self.query(request)
-        return {'address': address}
+        return {"address": address}
 
     def close(self):
         pass
 
-    ############ extra functions Specter supports ############
+    # extra functions Specter supports ############
 
-    def get_random(self, num_bytes:int=32):
+    def get_random(self, num_bytes: int = 32):
         if num_bytes < 0 or num_bytes > 10000:
             raise BadArgumentError("We can only get up to 10k bytes of random data")
         res = self.query("getrandom %d" % num_bytes)
         return bytes.fromhex(res)
 
-    def import_wallet(self, name:str, descriptor:str):
+    def import_wallet(self, name: str, descriptor: str):
         # TODO: implement
         pass
 
 
-def enumerate(password=''):
+def enumerate(password=""):
     """
-    Returns a list of detected Specter devices 
+    Returns a list of detected Specter devices
     with their fingerprints and client's paths
     """
     results = []
     # find ports with micropython's VID
-    ports = [port.device for port 
-                         in serial.tools.list_ports.comports()
-                         if is_micropython(port)]
+    ports = [
+        port.device
+        for port in serial.tools.list_ports.comports()
+        if is_micropython(port)
+    ]
     try:
         # check if there is a simulator on port 8789
         # and we can connect to it
@@ -154,48 +163,56 @@ def enumerate(password=''):
         try:
             path = port
             data = {
-                'type': 'specter',
-                'model': 'specter-diy',
-                'path': path,
-                'needs_passphrase': False
+                "type": "specter",
+                "model": "specter-diy",
+                "path": path,
+                "needs_passphrase": False,
             }
             client = SpecterClient(path)
-            data['fingerprint'] = client.get_master_fingerprint_hex()
+            data["fingerprint"] = client.get_master_fingerprint_hex()
             client.close()
             results.append(data)
         except Exception as e:
             print(e)
     return results
 
-############# Helper functions and base classes ##############
+
+# Helper functions and base classes ##############
+
 
 def xpub_test_2_main(xpub: str) -> str:
     data = base58.decode(xpub)
-    main_data = b'\x04\x88\xb2\x1e' + data[4:-4]
+    main_data = b"\x04\x88\xb2\x1e" + data[4:-4]
     checksum = base58.hash256(main_data)[0:4]
     return base58.encode(main_data + checksum)
+
 
 def is_micropython(port):
     return "VID:PID=F055:" in port.hwid.upper()
 
+
 class SpecterBase:
     """Class with common constants and command encoding"""
+
     EOL = b"\r\n"
     ACK = b"ACK"
     ACK_TIMOUT = 3
+
     def prepare_cmd(self, data):
         """
         Prepends command with 2*EOL and appends EOL at the end.
         Double EOL in the beginning makes sure all pending data
         will be cleaned up.
         """
-        return self.EOL*2 + data.encode('utf-8') + self.EOL
+        return self.EOL * 2 + data.encode("utf-8") + self.EOL
+
 
 class SpecterUSBDevice(SpecterBase):
     """
     Base class for USB device.
     Implements a simple query command over serial
     """
+
     def __init__(self, path):
         self.ser = serial.Serial(baudrate=115200, timeout=30)
         self.ser.port = path
@@ -207,9 +224,9 @@ class SpecterUSBDevice(SpecterBase):
             try:
                 raw = self.ser.read(1)
                 res += raw
-            except Exception as e:
+            except Exception:
                 time.sleep(0.01)
-            if timeout is not None and time.time() > t0+timeout:
+            if timeout is not None and time.time() > t0 + timeout:
                 self.ser.close()
                 raise DeviceBusyError("Timeout")
         return res
@@ -220,20 +237,22 @@ class SpecterUSBDevice(SpecterBase):
         self.ser.open()
         self.ser.write(self.prepare_cmd(data))
         # first we should get ACK
-        res = self.read_until(self.EOL, self.ACK_TIMOUT)[:-len(self.EOL)]
+        res = self.read_until(self.EOL, self.ACK_TIMOUT)[: -len(self.EOL)]
         # then we should get the data itself
         if res != self.ACK:
             self.ser.close()
             raise DeviceBusyError("Device didn't return ACK")
-        res = self.read_until(self.EOL, timeout)[:-len(self.EOL)]
+        res = self.read_until(self.EOL, timeout)[: -len(self.EOL)]
         self.ser.close()
         return res.decode()
+
 
 class SpecterSimulator(SpecterBase):
     """
     Base class for the simulator.
     Implements a simple query command over tcp/ip socket
     """
+
     def __init__(self, path):
         arr = path.split(":")
         self.sock_settings = (arr[0], int(arr[1]))
@@ -245,9 +264,9 @@ class SpecterSimulator(SpecterBase):
             try:
                 raw = s.recv(1)
                 res += raw
-            except Exception as e:
+            except Exception:
                 time.sleep(0.01)
-            if timeout is not None and time.time() > t0+timeout:
+            if timeout is not None and time.time() > t0 + timeout:
                 s.close()
                 raise DeviceBusyError("Timeout")
         return res
@@ -258,11 +277,10 @@ class SpecterSimulator(SpecterBase):
         s.send(self.prepare_cmd(data))
         s.setblocking(False)
         # we will get ACK right away
-        res = self.read_until(s, self.EOL, self.ACK_TIMOUT)[:-len(self.EOL)]
+        res = self.read_until(s, self.EOL, self.ACK_TIMOUT)[: -len(self.EOL)]
         if res != self.ACK:
             raise DeviceBusyError("Device didn't return ACK")
         # fetch with required timeout
-        res = self.read_until(s, self.EOL, timeout)[:-len(self.EOL)]
+        res = self.read_until(s, self.EOL, timeout)[: -len(self.EOL)]
         s.close()
         return res.decode()
-

--- a/hwilib/devices/specter.py
+++ b/hwilib/devices/specter.py
@@ -1,7 +1,7 @@
 # Specter interaction script
 import socket
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import serial
 import serial.tools.list_ports
@@ -31,6 +31,7 @@ class SpecterClient(HardwareWalletClient):
     def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
         super().__init__(path, password, expert)
         self.simulator = ":" in path
+        self.dev: Union[SpecterSimulator, SpecterUSBDevice]
         if self.simulator:
             self.dev = SpecterSimulator(path)
         else:


### PR DESCRIPTION
formatted with black (_black is opinionated so you don't have to_);
removed flake8 and mypy warnings;
removed unused imports;
isorted imports;
removed redundant base class doc-strings.

The module should be fully annotated, now it is only partially annotated.

```
[isort]
multi_line_output = 3
include_trailing_comma = True
force_grid_wrap = 0
use_parentheses = True
line_length = 80
```

```
[flake8]
exclude =
    # No need to traverse the git directory
    .git,
    # No value in checking cache directories
    __pycache__,
    # The conf file is mostly autogenerated, ignore it
    docs/source/conf.py,
    .tox,
    *.egg
max-line-length = 80
# B950: Line too long. It considers "max-line-length"
# but only triggers when the value has been exceeded
# by more than 10%. So the effective max line length is 88
# Disable E501 to avoid duplicate warnings.
select = C,E,F,W,B,B950
# E203 and W503 are not PEP 8 compliant
ignore = E203, E501, W503
# emit a warning for high McCabe complexity
# See https://en.wikipedia.org/wiki/Cyclomatic_complexity
max-complexity = 10
```
